### PR TITLE
Add encoding/decoding JSON strategies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,13 +5,16 @@ let package = Package(
     name: "Kebab",
     products: [
         .library(name: "Kebab", targets: ["Kebab"]),
-        .library(name: "KebabExtensions", targets: ["KebabExtensions"])
+        .library(name: "KebabExtensions", targets: ["KebabExtensions"]),
+        .library(name: "KebabJSON", targets: ["KebabJSON"])
     ],
     dependencies: [],
     targets: [
         .target(name: "Kebab", dependencies: []),
         .target(name: "KebabExtensions", dependencies: ["Kebab"]),
+        .target(name: "KebabJSON", dependencies: ["Kebab"]),
         .testTarget(name: "KebabTests", dependencies: ["Kebab"]),
-        .testTarget(name: "KebabExtensionsTests", dependencies: ["KebabExtensions"])
+        .testTarget(name: "KebabExtensionsTests", dependencies: ["KebabExtensions"]),
+        .testTarget(name: "KebabJSONTests", dependencies: ["KebabJSON"])
     ]
 )

--- a/Sources/KebabJSON/JSONStrategies.swift
+++ b/Sources/KebabJSON/JSONStrategies.swift
@@ -1,0 +1,78 @@
+//
+//  JSONStrategies.swift
+//  Kebab
+//
+//  Created by Eneko Alonso on 1/16/21.
+//
+
+import Foundation
+import Kebab
+
+// MARK: Encoding Strategies
+
+extension JSONEncoder.KeyEncodingStrategy {
+    static let converter = CaseConverter()
+
+    /// Encode keys in `PascalCase` format
+    public static var convertToPascalCase: Self {
+        .custom { keys in
+            let value = converter.convert(text: keys.last!.stringValue,
+                                          from: .camelCase,
+                                          to: .PascalCase)
+            return CustomKey(stringValue: value)
+        }
+    }
+
+    /// Encode keys in `kebab-case` format
+    public static var convertToKebabCase: Self {
+        .custom { keys in
+            let value = converter.convert(text: keys.last!.stringValue,
+                                          from: .camelCase,
+                                          to: .kebabCase)
+            return CustomKey(stringValue: value)
+        }
+    }
+}
+
+// MARK: Decoding Strategies
+
+extension JSONDecoder.KeyDecodingStrategy {
+    static let converter = CaseConverter()
+
+    /// Decode keys from `PascalCase` format
+    public static var convertFromPascalCase: Self {
+        .custom { keys in
+            let value = converter.convert(text: keys.last!.stringValue,
+                                          from: .PascalCase,
+                                          to: .camelCase)
+            return CustomKey(stringValue: value)
+        }
+    }
+
+    /// Decode keys from `kebab-case` format
+    public static var convertFromKebabCase: Self {
+        .custom { keys in
+            let value = converter.convert(text: keys.last!.stringValue,
+                                          from: .kebabCase,
+                                          to: .camelCase)
+            return CustomKey(stringValue: value)
+        }
+    }
+}
+
+// MARK: Custom Coding Key
+
+struct CustomKey: CodingKey {
+    let stringValue: String
+    let intValue: Int?
+
+    init(stringValue: String) {
+        self.stringValue = stringValue
+        intValue = nil
+    }
+
+    init(intValue: Int) {
+        self.intValue = intValue
+        stringValue = String(intValue)
+    }
+}

--- a/Tests/KebabJSONTests/KebabJSONTests.swift
+++ b/Tests/KebabJSONTests/KebabJSONTests.swift
@@ -1,0 +1,100 @@
+//
+//  KebabJSONTests.swift
+//  KebabJSONTests
+//
+//  Created by Eneko Alonso on 1/16/21.
+//
+
+import XCTest
+import KebabJSON
+
+final class KebabJSONTests: XCTestCase {
+
+    struct Dto: Codable, Equatable {
+        let propertyName: String
+        let anotherProperty: Int
+        let list: [Nested]
+
+        struct Nested: Codable, Equatable {
+            let nestedItem: String
+        }
+    }
+
+    // MARK: Pascal Case
+
+    func testDecodePascalCase() throws {
+        let json = """
+        {
+            "PropertyName": "Property Value",
+            "AnotherProperty": 42,
+            "List": [
+                {
+                    "NestedItem": "Forty Two"
+                }
+            ]
+        }
+        """
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromPascalCase
+        let decoded = try decoder.decode(Dto.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.propertyName, "Property Value")
+        XCTAssertEqual(decoded.anotherProperty, 42)
+        XCTAssertEqual(decoded.list.first?.nestedItem, "Forty Two")
+    }
+
+    func testEncodePascalCase() throws {
+        let dto = Dto(propertyName: "hello",
+                      anotherProperty: 77,
+                      list: [.init(nestedItem: "nested")])
+
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToPascalCase
+        let encoded = try encoder.encode(dto)
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromPascalCase
+        let decoded = try decoder.decode(Dto.self, from: encoded)
+
+        XCTAssertEqual(decoded, dto)
+    }
+
+    // MARK: Kebab Case
+
+    func testDecodeKebabCase() throws {
+        let json = """
+        {
+            "property-name": "Property Value",
+            "another-property": 42,
+            "list": [
+                {
+                    "nested-item": "Forty Two"
+                }
+            ]
+        }
+        """
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromKebabCase
+        let decoded = try decoder.decode(Dto.self, from: Data(json.utf8))
+        XCTAssertEqual(decoded.propertyName, "Property Value")
+        XCTAssertEqual(decoded.anotherProperty, 42)
+        XCTAssertEqual(decoded.list.first?.nestedItem, "Forty Two")
+    }
+
+    func testEncodeKebabCase() throws {
+        let dto = Dto(propertyName: "hello",
+                      anotherProperty: 77,
+                      list: [.init(nestedItem: "nested")])
+
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToKebabCase
+        let encoded = try encoder.encode(dto)
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromKebabCase
+        let decoded = try decoder.decode(Dto.self, from: encoded)
+
+        XCTAssertEqual(decoded, dto)
+    }
+}


### PR DESCRIPTION
## Enhancements
- Add JSON strategies for encoding and decoding keys in `PascalCase` and `kebab-case`. Additional strategies can be added later, though other case formats are much less common in JSON payloads.